### PR TITLE
raise a meaningfull error on ascii encoding

### DIFF
--- a/aesfield/field.py
+++ b/aesfield/field.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.db import models
-from django.db import connection
 from django.utils.importlib import import_module
+from django.utils.encoding import smart_str
 
 from m2secret import Secret
 
@@ -42,7 +42,7 @@ class AESField(models.TextField):
 
     def _encrypt(self, value):
         secret = Secret()
-        secret.encrypt(value, self.get_aes_key())
+        secret.encrypt(smart_str(value), self.get_aes_key())
         return secret.serialize()
 
     def to_python(self, value):

--- a/aesfield/tests.py
+++ b/aesfield/tests.py
@@ -1,3 +1,4 @@
+# -*- coding: utf8 -*-
 import os
 import tempfile
 
@@ -57,5 +58,14 @@ class TestBasic(TestCase):
         for k in ['foo',
                   '1234567890123456',
                   '12345678901234567',
-                  u'1'.encode('ascii')]:
+                  u'ራ'.encode('utf8')]:
             eq_(k, f._decrypt(f._encrypt(k)))
+
+    def test_not_encoded(self):
+        t = TestModel()
+        f = t._meta.get_field('key')
+        k = u'ራ'
+        # The unicode string was not encoded, it will only match when we
+        # force an encoding. Be sure you know what encoding is being stored,
+        # as ever.
+        eq_(k.encode('utf8'), f._decrypt(f._encrypt(k)))

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='django-aesfield',
-    version='0.1',
+    version='0.1.1',
     description='Django Model Field that supports AES encryption',
     long_description=open('README.rst').read(),
     author='Andy McKay',


### PR DESCRIPTION
Filed https://bugzilla.mozilla.org/show_bug.cgi?id=925968 to fix up m2secret, which isn't going to be easy.

Right now django-aesfield only works with ascii, this just makes it explicit and allows to upgrade to Django 1.5, which casts all input as utf8. The only fields we use this on are uuid like fields we generate.
