### PR TITLE
Bump version to 0.3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='django-aesfield',
-    version='0.1.2',
+    version='0.3.0',
     description='Django Model Field that supports AES encryption',
     long_description=open('README.rst').read(),
     author='Andy McKay',


### PR DESCRIPTION
This is to make sure some tools don't consider "0.2" (which [was released](https://pypi.python.org/pypi/django-aesfield/0.2) without a patch number) as newer than the current latest version.