### PR TITLE
Make sure we accept aes_method on init so that migrations work.

### DIFF
--- a/aesfield/field.py
+++ b/aesfield/field.py
@@ -19,14 +19,14 @@ class AESField(models.TextField):
         self.aes_prefix = kwargs.pop('aes_prefix', 'aes:')
         if not self.aes_prefix:
             raise ValueError('AES Prefix cannot be null.')
-        self.aes_method = getattr(settings, 'AES_METHOD', 'aesfield.default')
+        self.aes_method = kwargs.pop(
+            'aes_method', getattr(settings, 'AES_METHOD', 'aesfield.default'))
         self.aes_key = kwargs.pop('aes_key', '')
         super(AESField, self).__init__(*args, **kwargs)
 
     def deconstruct(self):
         name, path, args, kwargs = super(AESField, self).deconstruct()
         kwargs['aes_method'] = SettingsReference(self.aes_method, 'AES_METHOD')
-        # TODO: Should `aes_method` be present in the serialized form too?
         kwargs['aes_prefix'] = self.aes_prefix
         kwargs['aes_key'] = self.aes_key
         return name, path, args, kwargs

--- a/aesfield/tests/test_basic.py
+++ b/aesfield/tests/test_basic.py
@@ -62,3 +62,10 @@ class TestBasic(object):
         assert kwargs['aes_method'] == 'aesfield.default'
         assert kwargs['aes_prefix'] == 'aes:'
         assert kwargs['aes_key'] == ''
+
+    def test_reinitialize_with_deconstruct(self):
+        test_model = AESTestModel()
+        field = test_model._meta.get_field('key')
+        name, path, args, kwargs = field.deconstruct()
+
+        AESField(*args, **kwargs)


### PR DESCRIPTION
This is a regression in 1.0 and should be fixed in a new release.