### PR TITLE
Django2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,13 @@ python:
   - '3.6'
 
 env:
+  - DJANGO_VERSION=2.0.x
   - DJANGO_VERSION=1.11.x
-  - DJANGO_VERSION=1.10.x
-  - DJANGO_VERSION=1.9.x
   - DJANGO_VERSION=1.8.x
+matrix:
+  exclude:
+    - python: 2.7
+      env: DJANGO_VERSION=2.0.x
 
 install:
   - pip install tox

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import codecs
 from setuptools import setup, find_packages
 
 
-version = '1.1'
+version = '1.2'
 
 
 if sys.argv[-1] == 'publish':
@@ -23,7 +23,7 @@ def read(*parts):
 
 
 install_requires = [
-    'Django>=1.8,<1.11',
+    'Django>=1.8,<2.1',
     'm2secret-py3>=1.3'
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,28 +10,15 @@ commands =
 
 deps18 =
     https://github.com/django/django/archive/stable/1.8.x.tar.gz#egg=django
-deps19 =
-    https://github.com/django/django/archive/stable/1.9.x.tar.gz#egg=django
-deps110 =
-    https://github.com/django/django/archive/stable/1.10.x.tar.gz#egg=django
 deps111 =
     https://github.com/django/django/archive/stable/1.11.x.tar.gz#egg=django
-
+deps200 =
+    https://github.com/django/django/archive/stable/2.0.x.tar.gz#egg=django
 
 [testenv:2.7-1.8.x]
 basepython = python2.7
 deps =
     {[testenv]deps18}
-
-[testenv:2.7-1.9.x]
-basepython = python2.7
-deps =
-    {[testenv]deps19}
-
-[testenv:2.7-1.10.x]
-basepython = python2.7
-deps =
-    {[testenv]deps110}
 
 [testenv:2.7-1.11.x]
 basepython = python2.7
@@ -43,37 +30,27 @@ basepython = python3.5
 deps =
     {[testenv]deps18}
 
-[testenv:3.5-1.9.x]
-basepython = python3.5
-deps =
-    {[testenv]deps19}
-
-[testenv:3.5-1.10.x]
-basepython = python3.5
-deps =
-    {[testenv]deps110}
-
 [testenv:3.5-1.11.x]
 basepython = python3.5
 deps =
     {[testenv]deps111}
+
+[testenv:3.5-2.0.x]
+basepython = python3.5
+deps =
+    {[testenv]deps200}
 
 [testenv:3.6-1.8.x]
 basepython = python3.6
 deps =
     {[testenv]deps18}
 
-[testenv:3.6-1.9.x]
-basepython = python3.6
-deps =
-    {[testenv]deps19}
-
-[testenv:3.6-1.10.x]
-basepython = python3.6
-deps =
-    {[testenv]deps110}
-
 [testenv:3.6-1.11.x]
 basepython = python3.6
 deps =
     {[testenv]deps111}
+
+[testenv:3.6-2.0.x]
+basepython = python3.6
+deps =
+    {[testenv]deps200}


### PR DESCRIPTION
Add django 2 compatibility, test on django 2.

This removes support for Django 1.9 and 1.10.

Fixes #14  