### PR TITLE
Remove deprecated 'context' argument from from_db_value() method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,13 @@ language: python
 dist: xenial
 
 python:
-  - 2.7
   - 3.6
   - 3.7
+  - 3.8
 
 env:
-  - DJANGO_VERSION=1.11.x
-  - DJANGO_VERSION=2.0.x
-  - DJANGO_VERSION=2.1.x
-matrix:
-  exclude:
-    - python: 2.7
-      env: DJANGO_VERSION=2.0.x
-    - python: 2.7
-      env: DJANGO_VERSION=2.1.x
+  - DJANGO_VERSION=2.2.x
+  - DJANGO_VERSION=3.0.x
 
 install:
   - pip install tox

--- a/aesfield/field.py
+++ b/aesfield/field.py
@@ -42,7 +42,7 @@ class AESField(models.TextField):
 
     get_db_prep_lookup = get_prep_lookup = get_lookup = _no_lookup
 
-    def from_db_value(self, value, expression, connection, context):
+    def from_db_value(self, value, expression, connection):
         if not value or not value.startswith(self.aes_prefix):
             return value
         return self._decrypt(value[len(self.aes_prefix):])

--- a/tox.ini
+++ b/tox.ini
@@ -8,44 +8,37 @@ commands =
     pip install -e {toxinidir}[tests]
     pytest {toxinidir}
 
-deps111 =
-    https://github.com/django/django/archive/stable/1.11.x.tar.gz#egg=django
-deps200 =
-    https://github.com/django/django/archive/stable/2.0.x.tar.gz#egg=django
-deps210 =
-    https://github.com/django/django/archive/stable/2.1.x.tar.gz#egg=django
+deps220 =
+    https://github.com/django/django/archive/stable/2.2.x.tar.gz#egg=django
+deps300 =
+    https://github.com/django/django/archive/stable/3.0.x.tar.gz#egg=django
 
-[testenv:2.7-1.11.x]
-basepython = python2.7
-deps =
-    {[testenv]deps111}
-
-[testenv:3.6-1.11.x]
+[testenv:3.6-2.2.x]
 basepython = python3.6
 deps =
-    {[testenv]deps111}
+    {[testenv]deps220}
 
-[testenv:3.6-2.0.x]
+[testenv:3.6-3.0.x]
 basepython = python3.6
 deps =
-    {[testenv]deps200}
+    {[testenv]deps300}
 
-[testenv:3.6-2.1.x]
-basepython = python3.6
-deps =
-    {[testenv]deps210}
-
-[testenv:3.7-1.11.x]
+[testenv:3.7-2.2.x]
 basepython = python3.7
 deps =
-    {[testenv]deps111}
+    {[testenv]deps220}
 
-[testenv:3.7-2.0.x]
+[testenv:3.7-3.0.x]
 basepython = python3.7
 deps =
-    {[testenv]deps200}
+    {[testenv]deps300}
 
-[testenv:3.7-2.1.x]
-basepython = python3.7
+[testenv:3.8-2.2.x]
+basepython = python3.8
 deps =
-    {[testenv]deps210}
+    {[testenv]deps220}
+
+[testenv:3.8-3.0.x]
+basepython = python3.8
+deps =
+    {[testenv]deps300}


### PR DESCRIPTION
Also update test matrix to use latest supported versions of Python/Django.