### PR TITLE
Remove deprecated smart text

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -11,13 +11,13 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       max-parallel: 4
       fail-fast: false
       matrix:
-        python: [3.6, 3.7, 3.8, 3.9]
-        django: [2.2.17, 3.0.11, 3.1.3, 3.2rc1]
+        python: [3.8, 3.9, 3.10]
+        django: [3.2.13, 4.0.4]
 
     steps:
     - uses: actions/checkout@v2
@@ -28,7 +28,7 @@ jobs:
         python-version: ${{ matrix.python }}
     
     - name: install generic deps and django
-      run: pip install --upgrade pip setuptools wheel six django~=${{ matrix.django }}
+      run: pip install --upgrade pip setuptools wheel django~=${{ matrix.django }}
     
     - name: install package and deps
       run: pip install -e .

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -16,8 +16,8 @@ jobs:
       max-parallel: 4
       fail-fast: false
       matrix:
-        python: [3.8, 3.9, 3.10]
-        django: [3.2.13, 4.0.4]
+        python: ["3.8", "3.9", "3.10"]
+        django: ["3.2.13", "4.0.4"]
 
     steps:
     - uses: actions/checkout@v2
@@ -28,7 +28,7 @@ jobs:
         python-version: ${{ matrix.python }}
     
     - name: install generic deps and django
-      run: pip install --upgrade pip setuptools wheel django~=${{ matrix.django }}
+      run: pip install --upgrade pip setuptools wheel six django~=${{ matrix.django }}
     
     - name: install package and deps
       run: pip install -e .

--- a/aesfield/field.py
+++ b/aesfield/field.py
@@ -3,7 +3,7 @@ from importlib import import_module
 from django.conf import settings
 from django.db import models
 from django.db.migrations.writer import SettingsReference
-from django.utils.encoding import smart_bytes, smart_text
+from django.utils.encoding import smart_bytes, smart_str
 
 from m2secret import Secret
 
@@ -16,7 +16,7 @@ class AESField(models.TextField):
     description = 'A field that uses AES encryption.'
 
     def __init__(self, *args, **kwargs):
-        self.aes_prefix = smart_text(kwargs.pop('aes_prefix', u'aes:'))
+        self.aes_prefix = smart_str(kwargs.pop('aes_prefix', u'aes:'))
         if not self.aes_prefix:
             raise ValueError('AES Prefix cannot be null.')
         self.aes_method = kwargs.pop(
@@ -61,9 +61,9 @@ class AESField(models.TextField):
     def _encrypt(self, value):
         secret = Secret()
         secret.encrypt(smart_bytes(value), self.get_aes_key())
-        return smart_text(secret.serialize())
+        return smart_str(secret.serialize())
 
     def _decrypt(self, value):
         secret = Secret()
         secret.deserialize(value)
-        return smart_text(secret.decrypt(self.get_aes_key()))
+        return smart_str(secret.decrypt(self.get_aes_key()))

--- a/aesfield/tests/test_basic.py
+++ b/aesfield/tests/test_basic.py
@@ -2,7 +2,7 @@
 import tempfile
 
 from django.db import models
-from django.utils.encoding import force_bytes, force_text
+from django.utils.encoding import force_bytes, force_str
 
 import pytest
 
@@ -45,7 +45,7 @@ class TestBasic(object):
     def test_encrypt_decrypt(self, key):
         test_model = AESTestModel()
         field = test_model._meta.get_field('key')
-        assert force_text(key) == field._decrypt(field._encrypt(key))
+        assert force_str(key) == field._decrypt(field._encrypt(key))
 
     def test_not_encoded(self):
         test_model = AESTestModel()

--- a/setup.py
+++ b/setup.py
@@ -23,14 +23,14 @@ def read(*parts):
 
 
 install_requires = [
-    'Django>=2.2,<4.0',
+    'Django>=3.2,<5.0',
     'm2secret-py3>=1.3'
 ]
 
 
 test_requires = [
-    'pytest==3.1.2',
-    'pytest-django==3.1.2',
+    'pytest==7.1.2',
+    'pytest-django==4.5.2',
 ]
 
 
@@ -61,10 +61,9 @@ setup(
         'Topic :: Security :: Cryptography',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: Implementation :: CPython',
         'Framework :: Django',
     ]


### PR DESCRIPTION
This fixes `RemovedInDjango40Warning: smart_text() is deprecated in favor of smart_str()`